### PR TITLE
Redirect to root URL instead of dashboard

### DIFF
--- a/src/main/java/com/bitium/jira/servlet/SsoJiraLoginServlet.java
+++ b/src/main/java/com/bitium/jira/servlet/SsoJiraLoginServlet.java
@@ -88,7 +88,7 @@ public class SsoJiraLoginServlet extends SsoLoginServlet {
 
 	@Override
 	protected String getDashboardUrl() {
-		return saml2Config.getBaseUrl() + "/secure/Dashboard.jspa";
+		return saml2Config.getBaseUrl() + "/";
 	}
 
 	@Override


### PR DESCRIPTION
This attempts to fix a bug introduced in Jira 7.2.2 that caused the Jira "oops" 404 page to display after logging in with SAML.

For some reason I still don't understand, the `sendRedirect` method does not actually issue a 302 redirect when redirecting to `/secure/Dashboard.jspa`.  Redirecting to the root URL works fine.  Jira then immediately redirects to the user's default starting page.

Fixes #46.