### PR TITLE
Workaround for Dashboard 404 redirect bug

### DIFF
--- a/src/main/java/com/bitium/jira/servlet/SsoJiraLoginServlet.java
+++ b/src/main/java/com/bitium/jira/servlet/SsoJiraLoginServlet.java
@@ -88,7 +88,19 @@ public class SsoJiraLoginServlet extends SsoLoginServlet {
 
 	@Override
 	protected String getDashboardUrl() {
-		return saml2Config.getBaseUrl() + "/secure/Dashboard.jspa";
+		return saml2Config.getBaseUrl() + "/default.jsp";
+	}
+	
+	@Override
+	protected String filterRedirectUrl(String redirectUrl) {
+	    // Work around Jira issue with Dashboard redirects failing:
+	    // See: https://jira.atlassian.com/browse/JRA-63278
+	    if (redirectUrl.endsWith("/secure/Dashboard.jspa")) {
+	        return getDashboardUrl();
+	    }
+	    else {
+	        return redirectUrl;
+	    }
 	}
 
 	@Override


### PR DESCRIPTION
Since Jira 7.2.0 there has been an issue with redirecting to /secure/Dashboard.jspa

According to this upsteam Jira: https://jira.atlassian.com/browse/JRA-63278
it is related to redirecting to the dashboard URL with an absolute URL,
which this plugin does.

Not using absolute URLs seems to result to having to login twice, which
is not desirable. So the best solution at the moment is to filter a
redirect to: /secure/Dashboard.jspa with /default.jsp

Note: This commit depends on the following pull request being merged in atlassian-saml:
https://github.com/bitium/atlassian-saml/pull/7

This should fix #46 