### PR TITLE
Fix for issue 59 (fullName not used for auto-created accounts)

### DIFF
--- a/src/main/java/com/bitium/jira/servlet/SsoJiraLoginServlet.java
+++ b/src/main/java/com/bitium/jira/servlet/SsoJiraLoginServlet.java
@@ -61,7 +61,7 @@ public class SsoJiraLoginServlet extends SsoLoginServlet {
 
 			String fullName = credential.getAttributeAsString("cn");
 			String email = credential.getAttributeAsString("mail");
-			UserDetails newUserDetails = new UserDetails(username, username).withEmail(email);
+			UserDetails newUserDetails = new UserDetails(username, fullName).withEmail(email);
 			ApplicationUser newUser = userManager.createUser(newUserDetails);
 
 			addUserToGroup(newUser);


### PR DESCRIPTION
A simple solution for issue 59  (just fixes a typo).

Closes #59.